### PR TITLE
Add directive to ignore i18n

### DIFF
--- a/src/Validator.test.ts
+++ b/src/Validator.test.ts
@@ -16,7 +16,7 @@ describe('Validator', () => {
         },
         {
             name: 'Ignores when flagged',
-            html: '<span><!-- i18n-checker: disable --> Hello!</span>',
+            html: '<span><!-- i18n-checker:disable --> Hello!</span>',
             result: true,
         },
         {

--- a/src/Validator.test.ts
+++ b/src/Validator.test.ts
@@ -15,6 +15,11 @@ describe('Validator', () => {
             },
         },
         {
+            name: 'Ignores when flagged',
+            html: '<span><!-- i18n-checker: disable --> Hello!</span>',
+            result: true,
+        },
+        {
             name: 'Reports invalid i18n formats',
             html: '<span i18n="Hello">Hello!</span>',
             result: {


### PR DESCRIPTION
#### PR checklist

- [x] Ran `npm run lint` and `npm run test`
- [x] Added tests if applicable

#### What changes did you make?

```html
<span>
  <!-- i18n-checker disable -->
  support@beam.pro
</span>
```

Ignores the subtree.